### PR TITLE
Expose the secret as an environment variable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ permissions:
   packages: write # Allow this workflow to write to releases & packages
 
 env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   # IF YOU NEED TO PUBLISH A NPM PACKAGE THEN ENSURE A NPM_TOKEN SECRET IS SET
   # AND PUBLISH_NPM: TRUE. IF YOU WANT TO PUBLISH TO A PRIVATE NPM REGISTRY
   # THEN ENSURE THE NPM_REGISTRY_URL IS CHANGED


### PR DESCRIPTION
I was a bit too eager to remove the `GITHUB_TOKEN` lines from the environment variables setup. Although using the new mechanism I no longer need a Personal Access Token (PAT), the created **secret** must still be exposed as an **environment variable** for some of the action steps to pick it up. 

Signed-off-by: Ringo De Smet <ringo@de-smet.name>