### PR TITLE
Fix the plugin binary name

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,7 +5,7 @@ before:
   hooks:
     - make tfgen
 builds:
-  - binary: pulumi-resource-xyz
+  - binary: pulumi-resource-time
     dir: provider
     env:
       - CGO_ENABLED=0


### PR DESCRIPTION
Still bumped into an `xyz` from the boilerplate that needed to be replaced with `time`.

Signed-off-by: Ringo De Smet <ringo@de-smet.name>