### PR TITLE
Trigger the right make target.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
         with:
           python-version: ${{matrix.pythonversion}}
       - name: Build SDK
-        run: make build_${{ matrix.language }}_sdk
+        run: make build_${{ matrix.language }}
       - name: Check worktree clean
         run: |
           git update-index -q --refresh


### PR DESCRIPTION
These don't end with `_sdk`, just `build_python`, `build_dotnet`, ...

Signed-off-by: Ringo De Smet <ringo@de-smet.name>