### PR TITLE
Shorten the display name

### DIFF
--- a/provider/cmd/pulumi-resource-time/schema.json
+++ b/provider/cmd/pulumi-resource-time/schema.json
@@ -1,6 +1,6 @@
 {
     "name": "time",
-    "displayName": "Pulumi Time provider",
+    "displayName": "Time",
     "description": "A Pulumi package for creating and managing Time resources",
     "keywords": [
         "pulumi",

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -53,7 +53,7 @@ func Provider() tfbridge.ProviderInfo {
 		Name: "time",
 		// DisplayName is a way to be able to change the casing of the provider
 		// name when being displayed on the Pulumi registry
-		DisplayName: "Pulumi Time provider",
+		DisplayName: "Time",
 		// The default publisher for all packages is Pulumi.
 		// Change this to your personal name (or a company name) that you
 		// would like to be shown in the Pulumi Registry if this package is published
@@ -73,7 +73,7 @@ func Provider() tfbridge.ProviderInfo {
 		// category/cloud tag helps with categorizing the package in the Pulumi Registry.
 		// For all available categories, see `Keywords` in
 		// https://www.pulumi.com/docs/guides/pulumi-packages/schema/#package.
-		Keywords:   []string{
+		Keywords: []string{
 			"pulumi",
 			"time",
 			"category/utility",
@@ -95,7 +95,7 @@ func Provider() tfbridge.ProviderInfo {
 			// },
 		},
 		PreConfigureCallback: preConfigureCallback,
-		Resources:            map[string]*tfbridge.ResourceInfo{
+		Resources: map[string]*tfbridge.ResourceInfo{
 			// Map each resource in the Terraform provider to a Pulumi type. Two examples
 			// are below - the single line form is the common case. The multi-line form is
 			// needed only if you wish to override types or other default options.


### PR DESCRIPTION
Shorten the display name for the Pulumi Registry so it lists alphabetically under `t` rather than `p` of `Pulumi Time provider`.

Signed-off-by: Ringo De Smet <ringo@de-smet.name>